### PR TITLE
Change GENX workitem, workgroup mapping function to mangled get_local_id(), get_workgroup_id() names

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
@@ -110,37 +110,37 @@ class GENX_DeviceFunctionOp<string mnemonic, string device_function,
 // Thread index and Block index
 
 def GENX_ThreadIdXOp : GENX_DeviceFunctionOp<"workitem.id.x",
-                        "get_local_id", 0>;
+                        "_Z12get_local_idj", 0>;
 def GENX_ThreadIdYOp : GENX_DeviceFunctionOp<"workitem.id.y",
-                        "get_local_id", 1>;
+                        "_Z12get_local_idj", 1>;
 def GENX_ThreadIdZOp : GENX_DeviceFunctionOp<"workitem.id.z",
-                        "get_local_id", 2>;
+                        "_Z12get_local_idj", 2>;
 def GENX_BlockIdXOp : GENX_DeviceFunctionOp<"workgroup.id.x",
-                        "get_group_id", 0>;
+                        "_Z12get_group_idj", 0>;
 def GENX_BlockIdYOp : GENX_DeviceFunctionOp<"workgroup.id.y",
-                        "get_group_id", 1>;
+                        "_Z12get_group_idj", 1>;
 def GENX_BlockIdZOp : GENX_DeviceFunctionOp<"workgroup.id.z",
-                        "get_group_id", 2>;
+                        "_Z12get_group_idj", 2>;
 
 //===----------------------------------------------------------------------===//
 // Thread range and Block range
 
 def GENX_BlockDimXOp : GENX_DeviceFunctionOp<"workgroup.dim.x",
-                        "get_local_size", 0>;
+                        "_Z12get_local_sizej", 0>;
 
 def GENX_BlockDimYOp : GENX_DeviceFunctionOp<"workgroup.dim.y",
-                        "get_local_size", 1>;
+                        "_Z12get_local_sizej", 1>;
 
 def GENX_BlockDimZOp : GENX_DeviceFunctionOp<"workgroup.dim.z",
-                        "get_local_size", 2>;
+                        "_Z12get_local_sizej", 2>;
 
 def GENX_GridDimXOp : GENX_DeviceFunctionOp<"grid.dim.x",
-                        "get_global_size", 0>;
+                        "_Z12get_global_sizej", 0>;
 
 def GENX_GridDimYOp : GENX_DeviceFunctionOp<"grid.dim.y",
-                        "get_global_size", 1>;
+                        "_Z12get_global_sizej", 1>;
 
 def GENX_GridDimZOp : GENX_DeviceFunctionOp<"grid.dim.z",
-                        "get_global_size", 2>;
+                        "_Z12get_global_sizej", 2>;
 
 #endif // GENXIR_OPS

--- a/mlir/lib/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.cpp
@@ -37,6 +37,7 @@ static llvm::Value *createDeviceFunctionCall(llvm::IRBuilderBase &builder,
       false);                                       // no variadic arguments.
   llvm::Function *fn = dyn_cast<llvm::Function>(
       module->getOrInsertFunction(fnName, functionType).getCallee());
+  fn->setCallingConv(llvm::CallingConv::SPIR_FUNC);
   llvm::Value *fnOp0 = llvm::ConstantInt::get(
       llvm::Type::getInt32Ty(module->getContext()), parameter);
   return builder.CreateCall(fn, ArrayRef<llvm::Value *>(fnOp0));

--- a/mlir/test/Target/LLVMIR/genx.mlir
+++ b/mlir/test/Target/LLVMIR/genx.mlir
@@ -2,29 +2,29 @@
 
 llvm.func @genx_special_regs() -> i64 {
   // CHECK-LABEL: genx_special_regs
-  // CHECK: call i64 @get_local_id(i32 0)
+  // CHECK: call i64 @_Z12get_local_idj(i32 0)
   %1 = genx.workitem.id.x : i64
-  // CHECK: call i64 @get_local_id(i32 1)
+  // CHECK: call i64 @_Z12get_local_idj(i32 1)
   %2 = genx.workitem.id.y : i64
-  // CHECK: call i64 @get_local_id(i32 2)
+  // CHECK: call i64 @_Z12get_local_idj(i32 2)
   %3 = genx.workitem.id.z : i64
-  // CHECK: call i64 @get_group_id(i32 0)
+  // CHECK: call i64 @_Z12get_group_idj(i32 0)
   %4 = genx.workgroup.id.x : i64
-  // CHECK: call i64 @get_group_id(i32 1)
+  // CHECK: call i64 @_Z12get_group_idj(i32 1)
   %5 = genx.workgroup.id.y : i64
-  // CHECK: call i64 @get_group_id(i32 2)
+  // CHECK: call i64 @_Z12get_group_idj(i32 2)
   %6 = genx.workgroup.id.z : i64
-  // CHECK: call i64 @get_local_size(i32 0)
+  // CHECK: call i64 @_Z12get_local_sizej(i32 0)
   %7 = genx.workgroup.dim.x : i64
-  // CHECK: call i64 @get_local_size(i32 1)
+  // CHECK: call i64 @_Z12get_local_sizej(i32 1)
   %8 = genx.workgroup.dim.y : i64
-  // CHECK: call i64 @get_local_size(i32 2)
+  // CHECK: call i64 @_Z12get_local_sizej(i32 2)
   %9 = genx.workgroup.dim.z : i64
-  // CHECK: call i64 @get_global_size(i32 0)
+  // CHECK: call i64 @_Z12get_global_sizej(i32 0)
   %10 = genx.grid.dim.x : i64
-  // CHECK: call i64 @get_global_size(i32 1)
+  // CHECK: call i64 @_Z12get_global_sizej(i32 1)
   %11 = genx.grid.dim.y : i64
-  // CHECK: call i64 @get_global_size(i32 2)
+  // CHECK: call i64 @_Z12get_global_sizej(i32 2)
   %12 = genx.grid.dim.z : i64
 
   llvm.return %1 : i64


### PR DESCRIPTION
LLVM-SPIRV translator doesn't recognize the unmangled names as built in.  Also set SPIR_FUNC calling convention to the built in functions, 
