### PR TITLE
Revert "[GENX]: Implement GENX dialect amendOperation"

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
@@ -39,20 +39,18 @@ def GENX_Dialect : Dialect {
   let hasOperationAttrVerify = 1;
 
   let extraClassDeclaration = [{
+    /// Get the name of the attribute used to annotate external kernel
+    /// functions.
+    static StringRef getKernelFuncAttrName() { return "opencl.kernels"; }
     /// Get the name of the attribute used to annotate max work group size
-    /// required for kernel functions.
+    /// required for kernel functions
     static constexpr ::llvm::StringLiteral getMaxWorkGroupSizeAttrName() {
-      return ::llvm::StringLiteral("genx.max_work_group_size");
+      return ::llvm::StringLiteral("max_work_group_size");
     }
     /// Get the name of the attribute used to annotate exact work group size
     /// required for kernel functions.
     static constexpr ::llvm::StringLiteral getReqdWorkGroupSizeAttrName() {
-      return ::llvm::StringLiteral("genx.reqd_work_group_size");
-    }
-    /// Get the name for the attribute used to annotate the exact sub group 
-    /// size required for kernel functions.
-    static constexpr ::llvm::StringLiteral getReqdSubGroupSizeAttrName() {
-      return ::llvm::StringLiteral("genx.intel_reqd_sub_group_size");
+      return ::llvm::StringLiteral("reqd_work_group_size");
     }
 
     /// The address space value that represents global memory.
@@ -61,7 +59,13 @@ def GENX_Dialect : Dialect {
     static constexpr unsigned kSharedMemoryAddressSpace = 3;
     /// The address space value that represents private memory.
     static constexpr unsigned kPrivateMemoryAddressSpace = 0;
+
+    /// private:
+    ///  Attribute parseAttribute(DialectAsmParser& parser, Type type) const override;
+    ///  void printAttribute(Attribute attr, DialectAsmPrinter& p) const override;
   }];
+
+  /// let useDefaultAttributePrinterParser = 1;
 }
 
 //===----------------------------------------------------------------------===//
@@ -75,13 +79,13 @@ class GENX_Op<string mnemonic, list<Trait> traits = []> :
 //===----------------------------------------------------------------------===//
 // GENX intrinsic operations
 //===----------------------------------------------------------------------===//
-
 class GENX_IntrOp<string mnem, list<Trait> traits,
                   int numResults>
   : LLVM_IntrOpBase<GENX_Dialect, mnem, "genx_" # !subst(".", "_", mnem),
                     /*list<int> overloadedResults=*/[],
                     /*list<int> overloadedOperands=*/[],
                     traits, numResults>;
+
 
 //===----------------------------------------------------------------------===//
 // GENX special register op definitions

--- a/mlir/lib/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.cpp
@@ -13,7 +13,7 @@
 
 #include "mlir/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.h"
 #include "mlir/Dialect/LLVMIR/GENXDialect.h"
-#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/Target/LLVMIR/ModuleTranslation.h"
 
@@ -66,67 +66,38 @@ public:
   LogicalResult
   amendOperation(Operation *op, NamedAttribute attribute,
                  LLVM::ModuleTranslation &moduleTranslation) const final {
-    auto func = dyn_cast<LLVM::LLVMFuncOp>(op);
-    if (!func)
-      return failure();
-
-    llvm::LLVMContext &llvmContext = moduleTranslation.getLLVMContext();
-    llvm::Function *llvmFunc = moduleTranslation.lookupFunction(func.getName());
-
-    // Set max_work_group_size metadata.
-    if (attribute.getName() ==
-        GENX::GENXDialect::getMaxWorkGroupSizeAttrName()) {
-      llvmFunc->setCallingConv(llvm::CallingConv::SPIR_KERNEL);
-      auto value = attribute.getValue().dyn_cast<ArrayAttr>();
-      if (!value)
+    if (attribute.getName() == GENX::GENXDialect::getKernelFuncAttrName()) {
+      auto func = dyn_cast<LLVM::LLVMFuncOp>(op);
+      if (!func)
         return failure();
 
-      SmallVector<llvm::Metadata *, 3> metadata;
-      llvm::Type *i64 = llvm::IntegerType::get(llvmContext, 64);
-      for (int64_t i : extractFromI64ArrayAttr(attribute.getValue())) {
-        llvm::Constant *constant = llvm::ConstantInt::get(i64, i);
-        metadata.push_back(llvm::ConstantAsMetadata::get(constant));
-      }
-      llvm::MDNode *node = llvm::MDNode::get(llvmContext, metadata);
-      llvmFunc->setMetadata("max_work_group_size", node);
+      // For GPU kernels, set SPIR_KERNEL calling convention.
+      llvm::Function *llvmFunc =
+          moduleTranslation.lookupFunction(func.getName());
+      llvmFunc->setCallingConv(llvm::CallingConv::SPIR_KERNEL);
     }
 
-    // Set reqd_work_group_size metadata.
-    if (attribute.getName() ==
-        GENX::GENXDialect::getReqdWorkGroupSizeAttrName()) {
-      llvmFunc->setCallingConv(llvm::CallingConv::SPIR_KERNEL);
-      auto value = attribute.getValue().dyn_cast<ArrayAttr>();
+    // Set reqd_work_group_size metadata
+    if (GENX::GENXDialect::getReqdWorkGroupSizeAttrName() ==
+        attribute.getName()) {
+      auto func = dyn_cast<LLVM::LLVMFuncOp>(op);
+      if (!func)
+        return failure();
+      auto value = attribute.getValue().dyn_cast<DenseI32ArrayAttr>();
       if (!value)
         return failure();
-
+      llvm::LLVMContext &llvmContext = moduleTranslation.getLLVMContext();
       SmallVector<llvm::Metadata *, 3> metadata;
-      llvm::Type *i64 = llvm::IntegerType::get(llvmContext, 64);
-      for (int64_t i : extractFromI64ArrayAttr(attribute.getValue())) {
-        llvm::Constant *constant = llvm::ConstantInt::get(i64, i);
+      llvm::Type *i32 = llvm::IntegerType::get(llvmContext, 32);
+      for (int32_t i : value.asArrayRef()) {
+        llvm::Constant *constant = llvm::ConstantInt::get(i32, i);
         metadata.push_back(llvm::ConstantAsMetadata::get(constant));
       }
+      llvm::Function *llvmFunc =
+          moduleTranslation.lookupFunction(func.getName());
       llvm::MDNode *node = llvm::MDNode::get(llvmContext, metadata);
       llvmFunc->setMetadata("reqd_work_group_size", node);
     }
-
-    // Set intel_reqd_sub_group_size metadata.
-    if (attribute.getName() ==
-        GENX::GENXDialect::getReqdSubGroupSizeAttrName()) {
-      llvmFunc->setCallingConv(llvm::CallingConv::SPIR_KERNEL);
-      auto value = attribute.getValue().dyn_cast<ArrayAttr>();
-      if (!value)
-        return failure();
-
-      SmallVector<llvm::Metadata *, 3> metadata;
-      llvm::Type *i64 = llvm::IntegerType::get(llvmContext, 64);
-      for (int64_t i : extractFromI64ArrayAttr(attribute.getValue())) {
-        llvm::Constant *constant = llvm::ConstantInt::get(i64, i);
-        metadata.push_back(llvm::ConstantAsMetadata::get(constant));
-      }
-      llvm::MDNode *node = llvm::MDNode::get(llvmContext, metadata);
-      llvmFunc->setMetadata("intel_reqd_sub_group_size", node);
-    }
-
     return success();
   }
 };


### PR DESCRIPTION
Reverts pengtu/llvm-project#6. We need to add back the 'getKernelFuncAttrName()' to GENXOps.td and put the calling convention setting under checking this attribute instead of checking getReqdWorkGroupSizeAttrName().  I pushed the merge button prematurally.