### PR TITLE
[CI] Increase timeout

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     name: Build + LIT
     runs-on: ubuntu-latest
-    timeout-minutes: 150 
+    timeout-minutes: 200 
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
In https://github.com/pengtu/llvm-project/pull/23, we noticed that 150 mins is no longer enough.
