### PR TITLE
Fix assertion build failure

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     name: Build + LIT
     runs-on: ubuntu-latest
-    timeout-minutes: 200 
+    timeout-minutes: 500 
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,7 +17,7 @@ jobs:
         uses: llvm/actions/install-ninja@main
       - name: Configure
         run: |
-          cmake -B build -G Ninja llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="mlir" -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="SPIRV"
+          cmake -B build -G Ninja llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=true -DLLVM_ENABLE_PROJECTS="mlir" -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="SPIRV"
       - name: mlir-opt
         run: |
           ninja -C build mlir-opt

--- a/mlir/lib/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.cpp
@@ -285,9 +285,6 @@ static void createMatrixInit(llvm::IRBuilderBase &builder, llvm::Value *mat,
 static llvm::Value *createMatrixCopy(llvm::IRBuilderBase &builder,
                                      llvm::Value *res, llvm::Value *src,
                                      GENX::Scope scope) {
-  assert((isa<GENX::JointMatrixType>(res->getType()) &&
-          isa<GENX::JointMatrixType>(src->getType())) &&
-         "Expecting a joint matrix type");
   assert(false && "TODO");
   return nullptr;
 }


### PR DESCRIPTION
```
llvm-project/llvm/include/llvm/Support/Casting.h:549:46:   required from ‘bool llvm::isa(const From&) [with To = mlir::GENX::JointMatrixType; From = llvm::Type*]’
llvm-project/mlir/lib/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.cpp:239:3:   required from here
llvm-project/mlir/include/mlir/IR/StorageUniquerSupport.h:111:54: error: static assertion failed: casting from a non-convertible type
  111 |     static_assert(std::is_convertible<ConcreteT, T>::value,
      |                                                      ^~~~~
llvm-project/mlir/include/mlir/IR/StorageUniquerSupport.h:111:54: note: ‘std::integral_constant<bool, false>::value’ evaluates to false
llvm-project/mlir/include/mlir/IR/StorageUniquerSupport.h:113:16: error: request for member ‘getTypeID’ in ‘val’, which is of pointer type ‘const llvm::Type*’ (maybe you meant to use ‘->’ ?)
  113 |     return val.getTypeID() == getTypeID();
```