### PR TITLE
Update `libGenISAIntrinsics.a` with LLVM-17

### DIFF
--- a/mlir/lib/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.cpp
@@ -225,11 +225,6 @@ static llvm::Value *createGenISA2DBlockRead(
   llvm::Function *fn = llvm::GenISAIntrinsic::getDeclaration(
       module, llvm::GenISAIntrinsic::GenISA_LSC2DBlockRead, retTys);
   assert(fn && "GenISAIntrinsic::getDeclaration() returns NULL");
-  // Temporary workaround: IGC library build LLVM version (LLVM 14) has
-  // different Attribute enum. Remove after building IGC library with the LLVM
-  // mainline
-  fn->removeFnAttr(llvm::Attribute::NoUndef);
-  fn->setDoesNotThrow();
 
   // The IGC intrinsic requires the first argument be int64
   auto base = builder.CreatePointerCast(ptr, builder.getInt64Ty());


### PR DESCRIPTION
And remove the workaround for setting Func nounwind attribute.
