### PR TITLE
[GENX] Add `genx.matrix.2Dblockstore`

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
@@ -455,7 +455,7 @@ def GENX_Matrix2DBlockStoreOp : GENX_Op<"matrix.2Dblockstore">,
     I32Attr:$v_blocks,
     I1Attr:$transpose,
     I1Attr:$vnni_transform,
-    AnyInteger:$stored_val
+    FixedVectorOf<[GENX_MatrixElemType]>:$stored_val
   )> {
 
   let summary = "GENX 2D block store";
@@ -469,7 +469,7 @@ def GENX_Matrix2DBlockStoreOp : GENX_Op<"matrix.2Dblockstore">,
     $v_blocks - number of blocks to load
     $transpose - transpose the submatrix in vector register (useful for 32 bit element types)
     $vnni_transform - transpose and pack the submatrix in register (useful for < 32 bit element types)
-    $stored_val - value to store
+    $stored_val - block to store
 
     The $transpose and $vnni_transform are mutual exclusive. These transformations are used for
     the B matrix in MMA (DPAS) operations D = C + A * B, where A should have row-major layout in register

--- a/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
@@ -466,7 +466,7 @@ def GENX_Matrix2DBlockStoreOp : GENX_Op<"matrix.2Dblockstore">,
     $base_width, $base_height, $base_pitch - the shape of the memory array
     $x, $y, $tile_width, $tile_height - the starting offets and shape of the submatrix to load
     $elem_size_in_bits - 32 for f32, bf32; 16 for f16, int16, bf16; 8 for int8, int4, int2 and etc
-    $v_blocks - number of blocks to load
+    $v_blocks - number of blocks to store
     $transpose - transpose the submatrix in vector register (useful for 32 bit element types)
     $vnni_transform - transpose and pack the submatrix in register (useful for < 32 bit element types)
     $stored_val - block to store

--- a/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
@@ -443,7 +443,7 @@ def GENX_Matrix2DBlockLoadOp : GENX_Op<"matrix.2Dblockload">,
 
 def GENX_Matrix2DBlockStoreOp : GENX_Op<"matrix.2Dblockstore">,
   Arguments<(ins 
-    Arg<LLVM_PointerTo<GENX_MatrixElemType>, "", [MemRead]>:$ptr,
+    Arg<LLVM_PointerTo<GENX_MatrixElemType>, "", [MemWrite]>:$ptr,
     I32:$base_width,
     I32:$base_height,
     I32:$base_pitch,

--- a/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
@@ -441,6 +441,54 @@ def GENX_Matrix2DBlockLoadOp : GENX_Op<"matrix.2Dblockload">,
   let hasVerifier = 1;
 }
 
+def GENX_Matrix2DBlockStoreOp : GENX_Op<"matrix.2Dblockstore">,
+  Arguments<(ins 
+    Arg<LLVM_PointerTo<GENX_MatrixElemType>, "", [MemRead]>:$ptr,
+    I32:$base_width,
+    I32:$base_height,
+    I32:$base_pitch,
+    I32:$x,
+    I32:$y,
+    I32Attr:$elem_size_in_bits,
+    I32Attr:$tile_width,
+    I32Attr:$tile_height,
+    I32Attr:$v_blocks,
+    I1Attr:$transpose,
+    I1Attr:$vnni_transform,
+    AnyInteger:$stored_val
+  )> {
+
+  let summary = "GENX 2D block store";
+
+  string baseDescription = [{
+    The 'genx.matrix.2Dblockstore' operation stores to a submatrix from an array in memory.
+    $ptr - the base address of the memory array
+    $base_width, $base_height, $base_pitch - the shape of the memory array
+    $x, $y, $tile_width, $tile_height - the starting offets and shape of the submatrix to load
+    $elem_size_in_bits - 32 for f32, bf32; 16 for f16, int16, bf16; 8 for int8, int4, int2 and etc
+    $v_blocks - number of blocks to load
+    $transpose - transpose the submatrix in vector register (useful for 32 bit element types)
+    $vnni_transform - transpose and pack the submatrix in register (useful for < 32 bit element types)
+    $stored_val - value to store
+
+    The $transpose and $vnni_transform are mutual exclusive. These transformations are used for
+    the B matrix in MMA (DPAS) operations D = C + A * B, where A should have row-major layout in register
+    and B should have column-major layout.
+
+    If the submatrix contains out of bound elements of the memory array, they are filled with 0.
+  }];
+
+  string llvmBuilder = [{
+    createGenISA2DBlockWrite(op, builder, moduleTranslation);
+  }];
+    
+  let assemblyFormat = [{
+    operands attr-dict `:` `(` type(operands) `)`
+  }];
+
+  let hasVerifier = 1;
+}
+
 def GENX_IsJointMatrixType :
   CPred<"$_self.isa<::mlir::GENX::JointMatrixType>()">;
 

--- a/mlir/lib/Dialect/LLVMIR/IR/GENXOps.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/GENXOps.cpp
@@ -68,6 +68,22 @@ LogicalResult GENX::Matrix2DBlockLoadOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// genx.matrix.2Dblockstore
+//===----------------------------------------------------------------------===//
+
+LogicalResult GENX::Matrix2DBlockStoreOp::verify() {
+  if (getElemSizeInBits() != 8 && getElemSizeInBits() != 16 &&
+      getElemSizeInBits() != 32)
+    return this->emitOpError("invalid element size");
+
+  if (getTranspose() && getVnniTransform())
+    return this->emitOpError(
+        "transpose and vnni transform are mutually exclusive");
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // genx.matrix.load
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Dialect/LLVMIR/IR/GENXOps.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/GENXOps.cpp
@@ -74,11 +74,18 @@ LogicalResult GENX::Matrix2DBlockLoadOp::verify() {
 LogicalResult GENX::Matrix2DBlockStoreOp::verify() {
   if (getElemSizeInBits() != 8 && getElemSizeInBits() != 16 &&
       getElemSizeInBits() != 32)
-    return this->emitOpError("invalid element size");
+    return this->emitOpError(
+        "expecting 'elem_size_in_bits' to be 8, 16, or 32");
 
   if (getTranspose() && getVnniTransform())
     return this->emitOpError(
         "transpose and vnni transform are mutually exclusive");
+
+  std::optional<int> width = getConstantInt(getBaseWidth());
+  std::optional<int> pitch = getConstantInt(getBasePitch());
+  if (pitch && width && *pitch < *width)
+    return this->emitOpError(
+        "4th operand (base pitch) should be >= 2nd operand (base width)");
 
   return success();
 }

--- a/mlir/lib/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.cpp
@@ -257,6 +257,44 @@ createGenISA2DBlockRead(GENX::Matrix2DBlockLoadOp op,
   return builder.CreateCall(fn, args);
 }
 
+// Create a call to GenISA_LSC2DBlockWrite for storing to a 2D submatrix.
+static void
+createGenISA2DBlockWrite(GENX::Matrix2DBlockStoreOp op,
+                         llvm::IRBuilderBase &builder,
+                         LLVM::ModuleTranslation &moduleTranslation) {
+  llvm::Module *module = builder.GetInsertBlock()->getModule();
+  auto opTypes = op->getOperandTypes();
+  llvm::Function *fn = llvm::GenISAIntrinsic::getDeclaration(
+      module, llvm::GenISAIntrinsic::GenISA_LSC2DBlockWrite,
+      {moduleTranslation.convertType(opTypes[opTypes.size() - 1])});
+  assert(fn && "GenISAIntrinsic::getDeclaration() returns NULL");
+
+  SmallVector<llvm::Value *> args(
+      moduleTranslation.lookupValues(op.getOperands()));
+
+  // The IGC intrinsic requires the first argument be int64
+  assert(isa<llvm::PointerType>(args[0]->getType()) &&
+         "Expecting a pointer type");
+  args[0] = builder.CreatePointerCast(args[0], builder.getInt64Ty());
+  llvm::Value *lastOperand = args.pop_back_val();
+
+  llvm::ConstantInt *width = dyn_cast<llvm::ConstantInt>(args[1]);
+  llvm::ConstantInt *pitch = dyn_cast<llvm::ConstantInt>(args[2]);
+  assert((!width || !pitch || width->getZExtValue() <= pitch->getZExtValue()) &&
+         "Base pitch should be >= base width");
+
+  auto int32Ty = builder.getInt32Ty();
+  auto int1Ty = builder.getInt1Ty();
+  args.push_back(llvm::ConstantInt::get(int32Ty, op.getElemSizeInBits()));
+  args.push_back(llvm::ConstantInt::get(int32Ty, op.getTileWidth()));
+  args.push_back(llvm::ConstantInt::get(int32Ty, op.getTileHeight()));
+  args.push_back(llvm::ConstantInt::get(int32Ty, op.getVBlocks()));
+  args.push_back(llvm::ConstantInt::get(int1Ty, op.getTranspose()));
+  args.push_back(llvm::ConstantInt::get(int1Ty, op.getVnniTransform()));
+  args.push_back(lastOperand);
+  builder.CreateCall(fn, args);
+}
+
 // Create a call to SPIR function for loading a joint matrix.
 static llvm::Value *
 createMatrixLoad(llvm::IRBuilderBase &builder, llvm::Value *res,

--- a/mlir/lib/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.cpp
@@ -208,7 +208,7 @@ static llvm::Value *
 createGenISADPAS(GENX::MatrixDPASOp op, llvm::IRBuilderBase &builder,
                  LLVM::ModuleTranslation &moduleTranslation) {
   llvm::Module *module = builder.GetInsertBlock()->getModule();
-  auto opTypes = op->getOperandTypes();
+  TypeRange opTypes = op->getOperandTypes();
   llvm::Function *fn = llvm::GenISAIntrinsic::getDeclaration(
       module, llvm::GenISAIntrinsic::GenISA_dpas,
       {moduleTranslation.convertType(op->getResultTypes()[0]),
@@ -263,7 +263,7 @@ createGenISA2DBlockWrite(GENX::Matrix2DBlockStoreOp op,
                          llvm::IRBuilderBase &builder,
                          LLVM::ModuleTranslation &moduleTranslation) {
   llvm::Module *module = builder.GetInsertBlock()->getModule();
-  auto opTypes = op->getOperandTypes();
+  TypeRange opTypes = op->getOperandTypes();
   llvm::Function *fn = llvm::GenISAIntrinsic::getDeclaration(
       module, llvm::GenISAIntrinsic::GenISA_LSC2DBlockWrite,
       {moduleTranslation.convertType(opTypes[opTypes.size() - 1])});
@@ -277,11 +277,6 @@ createGenISA2DBlockWrite(GENX::Matrix2DBlockStoreOp op,
          "Expecting a pointer type");
   args[0] = builder.CreatePointerCast(args[0], builder.getInt64Ty());
   llvm::Value *lastOperand = args.pop_back_val();
-
-  llvm::ConstantInt *width = dyn_cast<llvm::ConstantInt>(args[1]);
-  llvm::ConstantInt *pitch = dyn_cast<llvm::ConstantInt>(args[2]);
-  assert((!width || !pitch || width->getZExtValue() <= pitch->getZExtValue()) &&
-         "Base pitch should be >= base width");
 
   auto int32Ty = builder.getInt32Ty();
   auto int1Ty = builder.getInt1Ty();

--- a/mlir/test/Dialect/LLVMIR/genx-invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/genx-invalid.mlir
@@ -23,6 +23,23 @@ func.func @matrix_2Dblockload(%ptr : !llvm.ptr<i32>, %base_height : i32, %x : i3
   %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32) -> vector<4xi32>
   llvm.return
 }
+
+// -----
+
+func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : i32) {
+  // expected-error @+1 {{'genx.matrix.2Dblockstore' op invalid element size}}
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=64:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, i32)
+  llvm.return
+}
+
+// -----
+
+func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : i32) {
+  // expected-error @+1 {{'genx.matrix.2Dblockstore' op transpose and vnni transform are mutually exclusive}}
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=true, vnni_transform=true} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, i32)
+  llvm.return
+}
+
 // -----
 
 func.func @joint_matrix_load(%ptr : !llvm.ptr<i32>, %stride : index) {

--- a/mlir/test/Dialect/LLVMIR/genx-invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/genx-invalid.mlir
@@ -27,7 +27,7 @@ func.func @matrix_2Dblockload(%ptr : !llvm.ptr<i32>, %base_height : i32, %x : i3
 // -----
 
 func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : i32) {
-  // expected-error @+1 {{'genx.matrix.2Dblockstore' op invalid element size}}
+  // expected-error @+1 {{'genx.matrix.2Dblockstore' op expecting 'elem_size_in_bits' to be 8, 16, or 32}}
   genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=64:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, i32)
   llvm.return
 }
@@ -37,6 +37,16 @@ func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_h
 func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : i32) {
   // expected-error @+1 {{'genx.matrix.2Dblockstore' op transpose and vnni transform are mutually exclusive}}
   genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=true, vnni_transform=true} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, i32)
+  llvm.return
+}
+
+// -----
+
+func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i32>, %base_height : i32, %x : i32, %y : i32, %stored_val : i32) {
+  %base_width = llvm.mlir.constant(4 : i32) : i32
+  %base_pitch = llvm.mlir.constant(2 : i32) : i32
+  // expected-error @+1 {{'genx.matrix.2Dblockstore' op 4th operand (base pitch) should be >= 2nd operand (base width)}}
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, i32)
   llvm.return
 }
 

--- a/mlir/test/Dialect/LLVMIR/genx-invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/genx-invalid.mlir
@@ -26,27 +26,27 @@ func.func @matrix_2Dblockload(%ptr : !llvm.ptr<i32>, %base_height : i32, %x : i3
 
 // -----
 
-func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : i32) {
+func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<4xi32>) {
   // expected-error @+1 {{'genx.matrix.2Dblockstore' op expecting 'elem_size_in_bits' to be 8, 16, or 32}}
-  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=64:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, i32)
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=64:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, vector<4xi32>)
   llvm.return
 }
 
 // -----
 
-func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : i32) {
+func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<4xi32>) {
   // expected-error @+1 {{'genx.matrix.2Dblockstore' op transpose and vnni transform are mutually exclusive}}
-  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=true, vnni_transform=true} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, i32)
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=true, vnni_transform=true} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, vector<4xi32>)
   llvm.return
 }
 
 // -----
 
-func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i32>, %base_height : i32, %x : i32, %y : i32, %stored_val : i32) {
+func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i32>, %base_height : i32, %x : i32, %y : i32, %stored_val : vector<4xi32>) {
   %base_width = llvm.mlir.constant(4 : i32) : i32
   %base_pitch = llvm.mlir.constant(2 : i32) : i32
   // expected-error @+1 {{'genx.matrix.2Dblockstore' op 4th operand (base pitch) should be >= 2nd operand (base width)}}
-  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, i32)
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, vector<4xi32>)
   llvm.return
 }
 

--- a/mlir/test/Dialect/LLVMIR/genx.mlir
+++ b/mlir/test/Dialect/LLVMIR/genx.mlir
@@ -125,6 +125,12 @@ func.func @genx.2Dblockload1x4.32.1.0.0(%ptr : !llvm.ptr<i32>, %base_width : i32
   llvm.return
 }
 
+func.func @genx.2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : i32) {
+  // CHECK: genx.matrix.2Dblockstore %arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6 {elem_size_in_bits = 32 : i32, tile_height = 1 : i32, tile_width = 4 : i32, transpose = false, v_blocks = 1 : i32, vnni_transform = false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, i32)
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, i32)
+  llvm.return
+}
+
 func.func @genx.matrix.load(%ptr : !llvm.ptr<vector<4xi32>>, %stride : index) {
   // CHECK-LABEL: genx.matrix.load
   // CHECK: %0 = genx.matrix.load <Subgroup> <RowMajor> %arg0, %arg1 {memory_access = #genx.memory_access<Volatile>} : (!llvm.ptr<vector<4xi32>>, index) -> !genx.jointmatrix<8x16xi32, RowMajor>

--- a/mlir/test/Dialect/LLVMIR/genx.mlir
+++ b/mlir/test/Dialect/LLVMIR/genx.mlir
@@ -125,9 +125,9 @@ func.func @genx.2Dblockload1x4.32.1.0.0(%ptr : !llvm.ptr<i32>, %base_width : i32
   llvm.return
 }
 
-func.func @genx.2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : i32) {
-  // CHECK: genx.matrix.2Dblockstore %arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6 {elem_size_in_bits = 32 : i32, tile_height = 1 : i32, tile_width = 4 : i32, transpose = false, v_blocks = 1 : i32, vnni_transform = false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, i32)
-  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, i32)
+func.func @genx.2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<4xi32>) {
+  // CHECK: genx.matrix.2Dblockstore %arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6 {elem_size_in_bits = 32 : i32, tile_height = 1 : i32, tile_width = 4 : i32, transpose = false, v_blocks = 1 : i32, vnni_transform = false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, vector<4xi32>)
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, vector<4xi32>)
   llvm.return
 }
 

--- a/mlir/test/Target/LLVMIR/genx.mlir
+++ b/mlir/test/Target/LLVMIR/genx.mlir
@@ -147,3 +147,10 @@ llvm.func @genx.2Dblockload1x4.32.1.0.0(%ptr : !llvm.ptr<i32>, %base_width : i32
   %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32) -> vector<4xi32>
   llvm.return
 }
+
+llvm.func @genx.2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : i32) {
+  // CHECK: [[PTR:%.*]] = ptrtoint ptr %0 to i64
+  // CHECK: call void @llvm.genx.GenISA.LSC2DBlockWrite.i32(i64 [[PTR]], i32 %1, i32 %2, i32 %3, i32 %4, i32 %5, i32 32, i32 4, i32 1, i32 1, i1 false, i1 false, i32 %6)
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, i32)
+  llvm.return
+}

--- a/mlir/test/Target/LLVMIR/genx.mlir
+++ b/mlir/test/Target/LLVMIR/genx.mlir
@@ -148,9 +148,9 @@ llvm.func @genx.2Dblockload1x4.32.1.0.0(%ptr : !llvm.ptr<i32>, %base_width : i32
   llvm.return
 }
 
-llvm.func @genx.2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : i32) {
+llvm.func @genx.2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<4xi32>) {
   // CHECK: [[PTR:%.*]] = ptrtoint ptr %0 to i64
-  // CHECK-NEXT: call void @llvm.genx.GenISA.LSC2DBlockWrite.i32(i64 [[PTR]], i32 %1, i32 %2, i32 %3, i32 %4, i32 %5, i32 32, i32 4, i32 1, i32 1, i1 false, i1 false, i32 %6)
-  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, i32)
+  // CHECK-NEXT: call void @llvm.genx.GenISA.LSC2DBlockWrite.v4i32(i64 [[PTR]], i32 %1, i32 %2, i32 %3, i32 %4, i32 %5, i32 32, i32 4, i32 1, i32 1, i1 false, i1 false, <4 x i32> %6)
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, vector<4xi32>)
   llvm.return
 }

--- a/mlir/test/Target/LLVMIR/genx.mlir
+++ b/mlir/test/Target/LLVMIR/genx.mlir
@@ -150,7 +150,7 @@ llvm.func @genx.2Dblockload1x4.32.1.0.0(%ptr : !llvm.ptr<i32>, %base_width : i32
 
 llvm.func @genx.2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : i32) {
   // CHECK: [[PTR:%.*]] = ptrtoint ptr %0 to i64
-  // CHECK: call void @llvm.genx.GenISA.LSC2DBlockWrite.i32(i64 [[PTR]], i32 %1, i32 %2, i32 %3, i32 %4, i32 %5, i32 32, i32 4, i32 1, i32 1, i1 false, i1 false, i32 %6)
+  // CHECK-NEXT: call void @llvm.genx.GenISA.LSC2DBlockWrite.i32(i64 [[PTR]], i32 %1, i32 %2, i32 %3, i32 %4, i32 %5, i32 32, i32 4, i32 1, i32 1, i1 false, i1 false, i32 %6)
   genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, i32)
   llvm.return
 }


### PR DESCRIPTION
The `genx.matrix.2Dblockstore` operation stores to a submatrix from an array in memory.