### PR TITLE
[GENX] Turn `MemoryFenceFlag` into `I32BitEnumAttr`

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
@@ -158,16 +158,20 @@ def GENX_BarrierOp : GENX_Op<"barrier"> {
 }
 
 /// Enum attribute of the different memory fence flags.
-def MemoryFenceFlag : I32EnumAttr<"MemoryFenceFlag", "GENX memory fence flag",
+def MemoryFenceFlag : I32BitEnumAttr<"MemoryFenceFlag", "GENX memory fence flag",
   [
-    I32EnumAttrCase<"LOCAL_MEM_FENCE",  1>,
-    I32EnumAttrCase<"GLOBAL_MEM_FENCE", 2>,
-    I32EnumAttrCase<"IMAGE_MEM_FENCE",  4>
+    I32BitEnumAttrCaseBit<"LOCAL_MEM_FENCE",  0>,
+    I32BitEnumAttrCaseBit<"GLOBAL_MEM_FENCE", 1>,
+    I32BitEnumAttrCaseBit<"IMAGE_MEM_FENCE",  2>
   ]> {
-  let genSpecializedAttr = 0;
+  let separator = ", ";
   let cppNamespace = "::mlir::GENX";
+  let genSpecializedAttr = 0;
+  let printBitEnumPrimaryGroups = 1;
 }
-def MemoryFenceFlagAttr : EnumAttr<GENX_Dialect, MemoryFenceFlag, "memory_fence_flag">;
+def MemoryFenceFlagAttr : EnumAttr<GENX_Dialect, MemoryFenceFlag, "memory_fence_flag"> {
+  let assemblyFormat = "`<` $value `>`";
+}
 
 /// Enum attribute of the different memory order.
 def MemoryOrder : I32EnumAttr<"MemoryOrder", "GENX memory order",
@@ -181,7 +185,9 @@ def MemoryOrder : I32EnumAttr<"MemoryOrder", "GENX memory order",
   let genSpecializedAttr = 0;
   let cppNamespace = "::mlir::GENX";
 }
-def MemoryOrderAttr : EnumAttr<GENX_Dialect, MemoryOrder, "memory_order">;
+def MemoryOrderAttr : EnumAttr<GENX_Dialect, MemoryOrder, "memory_order"> {
+  let assemblyFormat = "`<` $value `>`";
+}
 
 /// Enum attribute of the different memory scope.
 def MemoryScope : I32EnumAttr<"MemoryScope", "GENX memory scope",
@@ -195,10 +201,12 @@ def MemoryScope : I32EnumAttr<"MemoryScope", "GENX memory scope",
   let genSpecializedAttr = 0;
   let cppNamespace = "::mlir::GENX";
 }
-def MemoryScopeAttr : EnumAttr<GENX_Dialect, MemoryScope, "memory_scope">;
+def MemoryScopeAttr : EnumAttr<GENX_Dialect, MemoryScope, "memory_scope"> {
+  let assemblyFormat = "`<` $value `>`";
+}
 
 def GENX_FenceOp : GENX_Op<"atomic_work_item_fence">,
-  Arguments<(ins ConfinedAttr<I32Attr, [IntMinValue<0>, IntMaxValue<7>]>:$flags,
+  Arguments<(ins MemoryFenceFlagAttr:$flags,
                  MemoryOrderAttr:$order,
                  MemoryScopeAttr:$scope)> {
   let summary = "Fence of memory accesses";
@@ -215,7 +223,7 @@ def GENX_FenceOp : GENX_Op<"atomic_work_item_fence">,
     createFence(builder, $flags, $order, $scope);
   }];
   let assemblyFormat = [{
-    ` ` `<` custom<MemoryFenceFlags>($flags) ` ``>` `,` $order `,` $scope attr-dict
+    attr-dict
   }];
 }
 

--- a/mlir/lib/Dialect/LLVMIR/IR/GENXDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/GENXDialect.cpp
@@ -182,47 +182,5 @@ void GENXDialect::printType(Type type, DialectAsmPrinter &os) const {
       .Default([](Type) { llvm_unreachable("unhandled GENX type"); });
 }
 
-//===----------------------------------------------------------------------===//
-// Attribute parsing
-//===----------------------------------------------------------------------===//
-
-static mlir::ParseResult parseMemoryFenceFlags(OpAsmParser &parser,
-                                               IntegerAttr &flagsAttr) {
-  MemoryFenceFlagAttr memoryFenceFlagAttr;
-  int flags = 0;
-  do {
-    if (parser.parseCustomAttributeWithFallback(memoryFenceFlagAttr))
-      return failure();
-    flags |= static_cast<int>(memoryFenceFlagAttr.getValue());
-  } while (succeeded(parser.parseOptionalComma()));
-  flagsAttr =
-      IntegerAttr::get(IntegerType::get(parser.getContext(), 32), flags);
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
-// Attribute printing
-//===----------------------------------------------------------------------===//
-
-static void printMemoryFenceFlags(OpAsmPrinter &p, FenceOp op,
-                                  IntegerAttr flags) {
-  bool firstFlag = true;
-  auto printFlag = [&](int flag) {
-    assert(((flag == 1) || (flag == 2) || (flag == 4)) &&
-           "Expecting valid memory fence flag");
-    if (!firstFlag)
-      p << ",";
-    p.printStrippedAttrOrType(MemoryFenceFlagAttr::get(
-        flags.getContext(), static_cast<MemoryFenceFlag>(flag)));
-    firstFlag = false;
-  };
-  if (flags.getInt() & 1)
-    printFlag(1);
-  if (flags.getInt() & 2)
-    printFlag(2);
-  if (flags.getInt() & 4)
-    printFlag(4);
-}
-
 #define GET_OP_CLASSES
 #include "mlir/Dialect/LLVMIR/GENXOps.cpp.inc"

--- a/mlir/lib/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.cpp
@@ -43,14 +43,15 @@ static llvm::Value *createDeviceFunctionCall(llvm::IRBuilderBase &builder,
 }
 
 // Create a call to SPIR a "atomic_work_item_fence" function.
-static void createFence(llvm::IRBuilderBase &builder, uint32_t flags,
-                        GENX::MemoryOrder order, GENX::MemoryScope scope) {
+static void createFence(llvm::IRBuilderBase &builder,
+                        GENX::MemoryFenceFlag flags, GENX::MemoryOrder order,
+                        GENX::MemoryScope scope) {
   std::string fnName =
       "_Z22atomic_work_item_fencej12memory_order12memory_scope";
   llvm::IntegerType *i32Ty = builder.getInt32Ty();
   createDeviceFunctionCall(
       builder, fnName, builder.getVoidTy(), {i32Ty, i32Ty, i32Ty},
-      {llvm::ConstantInt::get(i32Ty, flags),
+      {llvm::ConstantInt::get(i32Ty, static_cast<int>(flags)),
        llvm::ConstantInt::get(i32Ty, static_cast<int>(order)),
        llvm::ConstantInt::get(i32Ty, static_cast<int>(scope))});
 }

--- a/mlir/test/Dialect/LLVMIR/genx.mlir
+++ b/mlir/test/Dialect/LLVMIR/genx.mlir
@@ -38,18 +38,18 @@ func.func @genx.barrier() {
 
 func.func @genx.atomic_work_item_fence() {
   // CHECK-LABEL: genx.atomic_work_item_fence
-  // CHECK: genx.atomic_work_item_fence < LOCAL_MEM_FENCE >,  Relaxed,  work_item
-  genx.atomic_work_item_fence <LOCAL_MEM_FENCE>, Relaxed, work_item
-  // CHECK: genx.atomic_work_item_fence < GLOBAL_MEM_FENCE >,  Acquire,  work_group
-  genx.atomic_work_item_fence <GLOBAL_MEM_FENCE>, Acquire, work_group
-  // CHECK: genx.atomic_work_item_fence < IMAGE_MEM_FENCE >,  Release,  device
-  genx.atomic_work_item_fence <IMAGE_MEM_FENCE>, Release, device
-  // CHECK: genx.atomic_work_item_fence < LOCAL_MEM_FENCE >,  AcquireRelease,  all_svm_devices
-  genx.atomic_work_item_fence <LOCAL_MEM_FENCE>, AcquireRelease, all_svm_devices
-  // CHECK: genx.atomic_work_item_fence < GLOBAL_MEM_FENCE >,  SequentiallyConsistent,  sub_group
-  genx.atomic_work_item_fence <GLOBAL_MEM_FENCE>, SequentiallyConsistent, sub_group
-  // CHECK: genx.atomic_work_item_fence < LOCAL_MEM_FENCE, IMAGE_MEM_FENCE >,  Acquire,  sub_group
-  genx.atomic_work_item_fence <LOCAL_MEM_FENCE, IMAGE_MEM_FENCE>, Acquire, sub_group
+  // CHECK: genx.atomic_work_item_fence {flags = #genx.memory_fence_flag<LOCAL_MEM_FENCE>, order = #genx.memory_order<Relaxed>, scope = #genx.memory_scope<work_item>}
+  genx.atomic_work_item_fence {flags=#genx.memory_fence_flag<LOCAL_MEM_FENCE>, order=#genx.memory_order<Relaxed>, scope=#genx.memory_scope<work_item>}
+  // CHECK: genx.atomic_work_item_fence {flags = #genx.memory_fence_flag<GLOBAL_MEM_FENCE>, order = #genx.memory_order<Acquire>, scope = #genx.memory_scope<work_group>}
+  genx.atomic_work_item_fence {flags=#genx.memory_fence_flag<GLOBAL_MEM_FENCE>, order=#genx.memory_order<Acquire>, scope=#genx.memory_scope<work_group>}
+  // CHECK: genx.atomic_work_item_fence {flags = #genx.memory_fence_flag<IMAGE_MEM_FENCE>, order = #genx.memory_order<Release>, scope = #genx.memory_scope<device>}
+  genx.atomic_work_item_fence {flags=#genx.memory_fence_flag<IMAGE_MEM_FENCE>, order=#genx.memory_order<Release>, scope=#genx.memory_scope<device>}
+  // CHECK: genx.atomic_work_item_fence {flags = #genx.memory_fence_flag<LOCAL_MEM_FENCE>, order = #genx.memory_order<AcquireRelease>, scope = #genx.memory_scope<all_svm_devices>}
+  genx.atomic_work_item_fence {flags=#genx.memory_fence_flag<LOCAL_MEM_FENCE>, order=#genx.memory_order<AcquireRelease>, scope=#genx.memory_scope<all_svm_devices>}
+  // CHECK: genx.atomic_work_item_fence {flags = #genx.memory_fence_flag<GLOBAL_MEM_FENCE>, order = #genx.memory_order<SequentiallyConsistent>, scope = #genx.memory_scope<sub_group>}
+  genx.atomic_work_item_fence {flags=#genx.memory_fence_flag<GLOBAL_MEM_FENCE>, order=#genx.memory_order<SequentiallyConsistent>, scope=#genx.memory_scope<sub_group>}
+  // CHECK: genx.atomic_work_item_fence {flags = #genx.memory_fence_flag<LOCAL_MEM_FENCE, IMAGE_MEM_FENCE>, order = #genx.memory_order<Acquire>, scope = #genx.memory_scope<sub_group>}
+  genx.atomic_work_item_fence {flags=#genx.memory_fence_flag<LOCAL_MEM_FENCE, IMAGE_MEM_FENCE>, order=#genx.memory_order<Acquire>, scope=#genx.memory_scope<sub_group>}
   llvm.return
 }
 

--- a/mlir/test/Target/LLVMIR/genx.mlir
+++ b/mlir/test/Target/LLVMIR/genx.mlir
@@ -40,17 +40,17 @@ llvm.func @genx.barrier() {
 llvm.func @genx.atomic_work_item_fence() {
   // CHECK-LABEL: genx.atomic_work_item_fence
   // CHECK: call void @_Z22atomic_work_item_fencej12memory_order12memory_scope(i32 1, i32 0, i32 0)
-  genx.atomic_work_item_fence <LOCAL_MEM_FENCE>, Relaxed, work_item
+  genx.atomic_work_item_fence {flags=#genx.memory_fence_flag<LOCAL_MEM_FENCE>, order=#genx.memory_order<Relaxed>, scope=#genx.memory_scope<work_item>}
   // CHECK: call void @_Z22atomic_work_item_fencej12memory_order12memory_scope(i32 2, i32 2, i32 1)
-  genx.atomic_work_item_fence <GLOBAL_MEM_FENCE>, Acquire, work_group
+  genx.atomic_work_item_fence {flags=#genx.memory_fence_flag<GLOBAL_MEM_FENCE>, order=#genx.memory_order<Acquire>, scope=#genx.memory_scope<work_group>}
   // CHECK: call void @_Z22atomic_work_item_fencej12memory_order12memory_scope(i32 4, i32 3, i32 2)
-  genx.atomic_work_item_fence <IMAGE_MEM_FENCE>, Release, device
+  genx.atomic_work_item_fence {flags=#genx.memory_fence_flag<IMAGE_MEM_FENCE>, order=#genx.memory_order<Release>, scope=#genx.memory_scope<device>}
   // CHECK: call void @_Z22atomic_work_item_fencej12memory_order12memory_scope(i32 1, i32 4, i32 3)
-  genx.atomic_work_item_fence <LOCAL_MEM_FENCE>, AcquireRelease, all_svm_devices
+  genx.atomic_work_item_fence {flags=#genx.memory_fence_flag<LOCAL_MEM_FENCE>, order=#genx.memory_order<AcquireRelease>, scope=#genx.memory_scope<all_svm_devices>}
   // CHECK: call void @_Z22atomic_work_item_fencej12memory_order12memory_scope(i32 2, i32 5, i32 4)
-  genx.atomic_work_item_fence <GLOBAL_MEM_FENCE>, SequentiallyConsistent, sub_group
+  genx.atomic_work_item_fence {flags=#genx.memory_fence_flag<GLOBAL_MEM_FENCE>, order=#genx.memory_order<SequentiallyConsistent>, scope=#genx.memory_scope<sub_group>}
   // CHECK: call void @_Z22atomic_work_item_fencej12memory_order12memory_scope(i32 5, i32 2, i32 4)
-  genx.atomic_work_item_fence <LOCAL_MEM_FENCE, IMAGE_MEM_FENCE>, Acquire, sub_group
+  genx.atomic_work_item_fence {flags=#genx.memory_fence_flag<LOCAL_MEM_FENCE, IMAGE_MEM_FENCE>, order=#genx.memory_order<Acquire>, scope=#genx.memory_scope<sub_group>}
   llvm.return
 }
 


### PR DESCRIPTION
By turning `MemoryFenceFlag` into `I32BitEnumAttr`, customize parser and printer for `MemoryFenceFlag` are no longer needed.