### PR TITLE
Revise GENX address space interface

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/GENXDialect.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/GENXDialect.h
@@ -33,11 +33,11 @@ namespace GENX {
 /// https://github.com/KhronosGroup/SPIRV-LLVM-Translator/blob/main/docs/SPIRVRepresentationInLLVM.rst#address-spaces
 ///
 enum GENXMemorySpace {
-  kFunction = 0         // OpenCL workitem address space 
+  kFunction = 0,        // OpenCL workitem address space 
   kCrossWorkgroup = 1,  // OpenCL Global memory
   kUniformConstant = 2, // OpenCL Constant memory
   kWorkgroup = 3,       // OpenCL Local memory
-  kGeneric = 4,         // OpenCL Generic memory
+  kGeneric = 4          // OpenCL Generic memory
 };
 
 } // namespace GENX

--- a/mlir/include/mlir/Dialect/LLVMIR/GENXDialect.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/GENXDialect.h
@@ -29,15 +29,16 @@
 namespace mlir {
 namespace GENX {
 
-/// GENX memory space identifiers.
+/// GENX memory space identifiers following SPIRV storage class convention
+/// https://github.com/KhronosGroup/SPIRV-LLVM-Translator/blob/main/docs/SPIRVRepresentationInLLVM.rst#address-spaces
+///
 enum GENXMemorySpace {
-  kCrossWorkgroup = 0,
-  kGeneric = 1,
-  kWorkgroup = 3,
-  kUniformConstant = 4,
-  kPrivate = 5,
-  kFunction = 6,
-  kImage = 7
+  kCrossWorkgroup = 1,  // OpenCL Global memory
+  kGeneric = 4,         // OpenCL Generic memory
+  kWorkgroup = 3,       // OpenCL Local memory
+  kUniformConstant = 2, // OpenCL Constant memory
+  kPrivate = 0,         // OpenCL workitem private address space
+  kFunction = 0         // OpenCL workitem address space 
 };
 
 } // namespace GENX

--- a/mlir/include/mlir/Dialect/LLVMIR/GENXDialect.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/GENXDialect.h
@@ -33,12 +33,11 @@ namespace GENX {
 /// https://github.com/KhronosGroup/SPIRV-LLVM-Translator/blob/main/docs/SPIRVRepresentationInLLVM.rst#address-spaces
 ///
 enum GENXMemorySpace {
-  kCrossWorkgroup = 1,  // OpenCL Global memory
-  kGeneric = 4,         // OpenCL Generic memory
-  kWorkgroup = 3,       // OpenCL Local memory
-  kUniformConstant = 2, // OpenCL Constant memory
-  kPrivate = 0,         // OpenCL workitem private address space
   kFunction = 0         // OpenCL workitem address space 
+  kCrossWorkgroup = 1,  // OpenCL Global memory
+  kUniformConstant = 2, // OpenCL Constant memory
+  kWorkgroup = 3,       // OpenCL Local memory
+  kGeneric = 4,         // OpenCL Generic memory
 };
 
 } // namespace GENX

--- a/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
@@ -70,13 +70,6 @@ def GENX_Dialect : Dialect {
     static constexpr ::llvm::StringLiteral getReqdSubGroupSizeAttrName() {
       return ::llvm::StringLiteral("genx.intel_reqd_sub_group_size");
     }
-
-    /// The address space value that represents global memory.
-    static constexpr unsigned kGlobalMemoryAddressSpace = 1;
-    /// The address space value that represents shared memory.
-    static constexpr unsigned kSharedMemoryAddressSpace = 3;
-    /// The address space value that represents private memory.
-    static constexpr unsigned kPrivateMemoryAddressSpace = 0;
   }];
 }
 

--- a/mlir/lib/Conversion/GPUToGENX/LowerGpuOpsToGENXOps.cpp
+++ b/mlir/lib/Conversion/GPUToGENX/LowerGpuOpsToGENXOps.cpp
@@ -102,7 +102,7 @@ struct LowerGpuOpsToGENXOpsPass
           case gpu::AddressSpace::Workgroup:
             return GENX::GENXMemorySpace::kWorkgroup;
           case gpu::AddressSpace::Private:
-            return GENX::GENXMemorySpace::kPrivate;
+            return GENX::GENXMemorySpace::kFunction;
           }
           llvm_unreachable("unknown address space enum value");
           return 0;
@@ -163,7 +163,7 @@ void mlir::populateGpuToGENXConversionPatterns(LLVMTypeConverter &converter,
           converter);
   patterns.add<GPUFuncOpLowering>(
       converter,
-      /*allocaAddrSpace=*/GENX::GENXMemorySpace::kPrivate,
+      /*allocaAddrSpace=*/GENX::GENXMemorySpace::kFunction,
       /*workgroupAddrSpace=*/GENX::GENXMemorySpace::kWorkgroup,
       StringAttr::get(&converter.getContext(),
                       GENX::GENXDialect::getKernelFuncAttrName()));

--- a/mlir/lib/Conversion/GPUToGENX/LowerGpuOpsToGENXOps.cpp
+++ b/mlir/lib/Conversion/GPUToGENX/LowerGpuOpsToGENXOps.cpp
@@ -98,11 +98,11 @@ struct LowerGpuOpsToGENXOpsPass
         converter, [](gpu::AddressSpace space) -> unsigned {
           switch (space) {
           case gpu::AddressSpace::Global:
-            return GENX::GENXDialect::kGlobalMemoryAddressSpace;
+            return GENX::GENXMemorySpace::kCrossWorkgroup;
           case gpu::AddressSpace::Workgroup:
-            return GENX::GENXDialect::kSharedMemoryAddressSpace;
+            return GENX::GENXMemorySpace::kWorkgroup;
           case gpu::AddressSpace::Private:
-            return GENX::GENXDialect::kPrivateMemoryAddressSpace;
+            return GENX::GENXMemorySpace::kPrivate;
           }
           llvm_unreachable("unknown address space enum value");
           return 0;
@@ -163,8 +163,8 @@ void mlir::populateGpuToGENXConversionPatterns(LLVMTypeConverter &converter,
           converter);
   patterns.add<GPUFuncOpLowering>(
       converter,
-      /*allocaAddrSpace=*/GENX::GENXDialect::kPrivateMemoryAddressSpace,
-      /*workgroupAddrSpace=*/GENX::GENXDialect::kSharedMemoryAddressSpace,
+      /*allocaAddrSpace=*/GENX::GENXMemorySpace::kPrivate,
+      /*workgroupAddrSpace=*/GENX::GENXMemorySpace::kWorkgroup,
       StringAttr::get(&converter.getContext(),
                       GENX::GENXDialect::getKernelFuncAttrName()));
 }

--- a/mlir/lib/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.cpp
@@ -117,10 +117,10 @@ static llvm::Value *createAtomicCmpXchg(llvm::IRBuilderBase &builder,
 
   std::string fnName = "_Z12atom_cmpxchgPU";
   switch (addrSpace) {
-  case mlir::GENX::GENXDialect::kGlobalMemoryAddressSpace:
+  case mlir::GENX::GENXMemorySpace::kCrossWorkgroup:
     fnName += "8CLglobal";
     break;
-  case mlir::GENX::GENXDialect::kSharedMemoryAddressSpace:
+  case mlir::GENX::GENXMemorySpace::kWorkgroup:
     fnName += "7CLlocal";
     break;
   default:
@@ -179,10 +179,10 @@ static llvm::Value *createAtomicRMW(llvm::IRBuilderBase &builder,
   }
 
   switch (addrSpace) {
-  case mlir::GENX::GENXDialect::kGlobalMemoryAddressSpace:
+  case mlir::GENX::GENXMemorySpace::kCrossWorkgroup:
     fnName += "8CLglobal";
     break;
-  case mlir::GENX::GENXDialect::kSharedMemoryAddressSpace:
+  case mlir::GENX::GENXMemorySpace::kWorkgroup:
     fnName += "7CLlocal";
     break;
   default:


### PR DESCRIPTION
Revise the GENXMemorySpace enum to match LLVM-SPIRV-Translator/OpenCL.  Also remove the redundant kAddressSpace* constants and replace their usages in MLIR GPU to LLVMIR conversion with the GENXMemorySpace enum. 

The change to the enum is required to support __spirv_ocl_print( i8 addrspace(2)*, ...), where the format string is from the UniformConstant address space of '2'.