### PR TITLE
[GENX] Set convergent attribute for barrier

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
@@ -144,7 +144,8 @@ def GENX_BarrierOp : GENX_Op<"barrier"> {
     llvm::Type *argType = builder.getInt32Ty();
     int memFence = 3; // local + global memory fence
     llvm::Value *arg = llvm::ConstantInt::get(argType, memFence);
-    createDeviceFunctionCall(builder, "_Z7barrierj", retType, {argType}, {arg});
+    llvm::CallInst *ci = createDeviceFunctionCall(builder, "_Z7barrierj", retType, {argType}, {arg});
+    ci->setCannotDuplicate();
   }];
 
   let assemblyFormat = "attr-dict";

--- a/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
@@ -145,7 +145,10 @@ def GENX_BarrierOp : GENX_Op<"barrier"> {
     int memFence = 3; // local + global memory fence
     llvm::Value *arg = llvm::ConstantInt::get(argType, memFence);
     llvm::CallInst *ci = createDeviceFunctionCall(builder, "_Z7barrierj", retType, {argType}, {arg});
-    ci->setCannotDuplicate();
+    ci->setConvergent();
+    llvm::Function *callee = dyn_cast_or_null<llvm::Function>(ci->getCalledOperand());
+    assert(callee && "Expected valid callee");
+    callee->setConvergent();
   }];
 
   let assemblyFormat = "attr-dict";

--- a/mlir/lib/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.cpp
@@ -28,11 +28,11 @@ using namespace mlir::LLVM;
 using mlir::LLVM::detail::createIntrinsicCall;
 
 // Create a call to SPIR device function.
-static llvm::Value *createDeviceFunctionCall(llvm::IRBuilderBase &builder,
-                                             StringRef fnName,
-                                             llvm::Type *retType,
-                                             ArrayRef<llvm::Type *> argTypes,
-                                             ArrayRef<llvm::Value *> args) {
+static llvm::CallInst *createDeviceFunctionCall(llvm::IRBuilderBase &builder,
+                                                StringRef fnName,
+                                                llvm::Type *retType,
+                                                ArrayRef<llvm::Type *> argTypes,
+                                                ArrayRef<llvm::Value *> args) {
   llvm::Module *module = builder.GetInsertBlock()->getModule();
   auto *functionType =
       llvm::FunctionType::get(retType, argTypes, /*isVarArg*/ false);

--- a/mlir/test/Target/LLVMIR/genx.mlir
+++ b/mlir/test/Target/LLVMIR/genx.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-translate -mlir-to-llvmir %s | FileCheck %s
+// RUN: mlir-translate -mlir-to-llvmir -split-input-file %s | FileCheck %s
 
 llvm.func @genx_special_regs() -> i64 {
   // CHECK-LABEL: genx_special_regs
@@ -30,12 +30,17 @@ llvm.func @genx_special_regs() -> i64 {
   llvm.return %1 : i64
 }
 
+// -----
+
 llvm.func @genx.barrier() {
   // CHECK-LABEL: genx.barrier
-  // CHECK: call void @_Z7barrierj(i32 3)
+  // CHECK: call void @_Z7barrierj(i32 3) [[NODUP:#.*]]
   genx.barrier
   llvm.return
 }
+// CHECK: attributes [[NODUP]] = { noduplicate }
+
+// -----
 
 llvm.func @genx.atomic_work_item_fence() {
   // CHECK-LABEL: genx.atomic_work_item_fence
@@ -53,6 +58,8 @@ llvm.func @genx.atomic_work_item_fence() {
   genx.atomic_work_item_fence {flags=#genx.memory_fence_flag<LOCAL_MEM_FENCE, IMAGE_MEM_FENCE>, order=#genx.memory_order<Acquire>, scope=#genx.memory_scope<sub_group>}
   llvm.return
 }
+
+// -----
 
 llvm.func @genx.sub_group_shuffle() {
   // CHECK-LABEL: genx.sub_group_shuffle
@@ -86,6 +93,8 @@ llvm.func @genx.sub_group_shuffle() {
   llvm.return
 }
 
+// -----
+
 llvm.func @genx.atomic.cmpxchg.global.i32(%ptr : !llvm.ptr<i32, 1>, %cmp : i32, %val : i32)  {
   // CHECK-LABEL: genx.atomic.cmpxchg.global.i32
   // CHECK: call i32 @_Z12atom_cmpxchgPU8CLglobalViii(ptr addrspace(1) %0, i32 %1, i32 %2)
@@ -99,6 +108,8 @@ llvm.func @genx.atomic.cmpxchg.shared.u64(%ptr : !llvm.ptr<i64, 3>, %cmp : i64, 
   %0 = genx.atomic.cmpxchg %ptr, %cmp, %val : (!llvm.ptr<i64, 3>, i64, i64) -> i64
   llvm.return
 }
+
+// -----
 
 llvm.func @genx.atomic.rmw(%ptr : !llvm.ptr<i32, 1>, %sptr : !llvm.ptr<i64, 3>, %val1 : i32, %val2 : i64) {
   // CHECK-LABEL: genx.atomic.rmw
@@ -135,6 +146,8 @@ llvm.func @genx.atomic.rmw(%ptr : !llvm.ptr<i32, 1>, %sptr : !llvm.ptr<i64, 3>, 
   llvm.return
 }
 
+// -----
+
 llvm.func @genx.dpas.f32(%c : vector<8xf32>, %a : vector<4xf32>, %b : vector<8xf32>) {
   // CHECK-DAG:  [[A:%.*]] = bitcast <4 x float> %1 to <8 x i16>
   // CHECK-DAG:  [[B:%.*]] = bitcast <8 x float> %2 to <8 x i32>
@@ -159,12 +172,16 @@ llvm.func @genx.dpas.i8(%c : vector<8xi32>, %a : vector<16xi8>, %b : vector<32xi
   llvm.return
 }
 
+// -----
+
 llvm.func @genx.2Dblockload1x4.32.1.0.0(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
   // CHECK: [[PTR:%.*]] = ptrtoint ptr %0 to i64
   // CHECK-NEXT: call <4 x i32> @llvm.genx.GenISA.LSC2DBlockRead.v4i32(i64 [[PTR]], i32 %1, i32 %2, i32 %3, i32 %4, i32 %5, i32 32, i32 4, i32 1, i32 1, i1 false, i1 false)
   %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32) -> vector<4xi32>
   llvm.return
 }
+
+// -----
 
 llvm.func @genx.2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<4xi32>) {
   // CHECK: [[PTR:%.*]] = ptrtoint ptr %0 to i64

--- a/mlir/test/Target/LLVMIR/genx.mlir
+++ b/mlir/test/Target/LLVMIR/genx.mlir
@@ -34,11 +34,11 @@ llvm.func @genx_special_regs() -> i64 {
 
 llvm.func @genx.barrier() {
   // CHECK-LABEL: genx.barrier
-  // CHECK: call void @_Z7barrierj(i32 3) [[NODUP:#.*]]
+  // CHECK: call void @_Z7barrierj(i32 3) [[ATTR:#.*]]
   genx.barrier
   llvm.return
 }
-// CHECK: attributes [[NODUP]] = { noduplicate }
+// CHECK: attributes [[ATTR]] = { convergent }
 
 // -----
 


### PR DESCRIPTION
JumpThreading transformation in LLVM opt may optimize blocks containing `_Z7barrierj()`, like

Before optimization:
```
  br %cond, bb1, bb2
bb1:
  <A>
  br bb2
bb2:
  _Z7barrierj()
  br %cond, bb3, bb4
bb3:
  <B>
  br bb4
bb4:
```
After optimization:
```
  br %cond, bb1, bb2
bb1:
  <A>
  _Z7barrierj()
  <B>
  br bb4
bb2:
  _Z7barrierj()
  br bb4
bb4:
```

The optimized code dead lock, i.e., never terminate.
To prevent JumpThreading from performing such optimization, this PR adds `convergent` attribute to the `_Z7barrierj` call instruction.